### PR TITLE
Fix resize throttle config. Wrong accessing of the configuration

### DIFF
--- a/src/withSizes.js
+++ b/src/withSizes.js
@@ -54,7 +54,7 @@ const withSizes = (...mappedSizesToProps) => WrappedComponent => {
 
     throttledDispatchSizes = throttle(
       this.dispatchSizes,
-      this.context.throttle || 200
+      (this.context[contextKey] || {}).throttle || 200
     )
 
     /* Lifecycles */


### PR DESCRIPTION
Currently it is not possible due to a bug to configure the throttle which is uses to delay the rerender of react when the browser window size changes. The default value is 200ms. 

It is supposed to be possible to configure the throttle by using the `SizesProvider` provider component. This provider however stores the config under `this.context['_ReactSizesConfig_'].throttle` and not directly under `this.context.throttle`. This merge request fixes this. 

Tested by setting up a react app which uses the `SizesProvider` to configure the throttle. The app simple prints the current width/height into a div

```
<SizesProvider config={{throttle:1}}>
        <TestComponent/>
</SizesProvider>
```

See issue https://github.com/renatorib/react-sizes/issues/27 for more details about the bug